### PR TITLE
feat(builder): add document handling with `documentOrNew` and `docume…

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -27,6 +27,7 @@ use RuntimeException;
  * @method Results aggregate(string $function, array $wheres, array $options, array $columns)
  * @method Results distinct(array $wheres, array $options, array $columns, bool $includeDocCount = false)
  * @method Results find(array $wheres, array $options, array $columns)
+ * @method Results getDocument(string $id)
  * @method Results save(array $data, string $refresh)
  * @method array insertBulk(array $data, bool $returnData = false, string|null $refresh = false)
  * @method Results multipleAggregate(array $functions, array $wheres, array $options, string $column)

--- a/src/Eloquent/Docs/ModelDocs.php
+++ b/src/Eloquent/Docs/ModelDocs.php
@@ -53,6 +53,8 @@ use PDPhilip\Elasticsearch\Query\Builder;
  * @method static $this whereRegex(string $column, string $regex)
  * @method static $this whereNestedObject(string $column, Callable $callback, string $scoreType = 'avg')
  * @method static $this whereNotNestedObject(string $column, Callable $callback, string $scoreType = 'avg')
+ * @method static $this documentOrNew(string $id)
+ * @method static $this documentOrFail(string $id)
  * @method static $this firstOrCreate(array $attributes, array $values = [])
  * @method static $this firstOrCreateWithoutRefresh(array $attributes, array $values = [])
  * @method static $this orderBy(string $column, string $direction = 'asc')

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -173,7 +173,36 @@ test('No Document', function () {
 test('Find Or Fail', function () {
     $this->expectException(ModelNotFoundException::class);
     Product::findOrFail('51c33d8981fec6813e00000a');
+});
 
+test('Document Or New', function () {
+    $product = Product::documentOrNew('51c33d8981fec6813e00000a');
+    expect($product->exists)->toBe(false)
+        ->and($product['_id'])->toBe('51c33d8981fec6813e00000a');
+
+    $product['name'] = 'John Doe';
+    $product['description'] = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus lacinia odio vitae vestibulum vestibulum.';
+    $product['in_stock'] = 35;
+    $product->save();
+
+    $getDocument = Product::documentOrNew('51c33d8981fec6813e00000a');
+    expect($getDocument->exists)->toBe(true)->and($product['_id'])->toBe('51c33d8981fec6813e00000a');
+});
+
+test('Document Or Fail', function () {
+    $this->expectException(ModelNotFoundException::class);
+    Product::documentOrFail('51c33d8981fec6813e00000a');
+});
+
+test('Document Or Fail (Found)', function () {
+    $product = new Product;
+    $product['name'] = 'John Doe';
+    $product['description'] = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus lacinia odio vitae vestibulum vestibulum.';
+    $product['in_stock'] = 24;
+    $product['_id'] = '51c33d8981fec6813e00000a';
+    $product->save();
+    $getDocument = Product::documentOrFail('51c33d8981fec6813e00000a');
+    expect($getDocument->exists)->toBe(true)->and($product['_id'])->toBe('51c33d8981fec6813e00000a');
 });
 
 test('Create', function () {


### PR DESCRIPTION
…ntOrFail`

- Introduced `documentOrNew` and `documentOrFail` methods in `Builder` for better document management.
- Enhanced `Connection` with `getDocument` method for fetching documents by ID.
- Added `processGetDocument` and `_returnDocument` methods to `Bridge` for document retrieval.
- Implemented `_sanitizeGetResponse` for processing single document responses.
- Included tests for `documentOrNew` and `documentOrFail` scenarios.

Because fetching documents should never feel like hide-and-seek! 😎